### PR TITLE
`v1.1.0-SNAPSHOT`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.archyx</groupId>
     <artifactId>Krypton</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Krypton</name>
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.7</version>
+            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/archyx/krypton/Krypton.java
+++ b/src/main/java/com/archyx/krypton/Krypton.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 public final class Krypton extends JavaPlugin {
 
+    private final CaptchaActivator captchaActivator = new CaptchaActivator(this);
     private CaptchaManager manager;
     private MapGenerator generator;
     private OptionL optionL;
@@ -75,7 +76,7 @@ public final class Krypton extends JavaPlugin {
 
     private void registerEvents() {
         PluginManager pm = Bukkit.getPluginManager();
-        pm.registerEvents(new CaptchaActivator(this), this);
+        pm.registerEvents(captchaActivator, this);
         pm.registerEvents(new CaptchaBlockers(this), this);
         pm.registerEvents(new CaptchaListener(this), this);
         if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
@@ -111,6 +112,8 @@ public final class Krypton extends JavaPlugin {
     public OptionL getOptionL() {
         return optionL;
     }
+
+    public CaptchaActivator getActivator() { return captchaActivator; }
 
     public CaptchaManager getManager() {
         return manager;

--- a/src/main/java/com/archyx/krypton/captcha/CaptchaActivateReason.java
+++ b/src/main/java/com/archyx/krypton/captcha/CaptchaActivateReason.java
@@ -1,0 +1,7 @@
+package com.archyx.krypton.captcha;
+
+public enum CaptchaActivateReason {
+    FROM_JOIN,
+    FROM_PLUGIN,
+    FROM_PREVIOUS_SESSION
+}

--- a/src/main/java/com/archyx/krypton/configuration/Option.java
+++ b/src/main/java/com/archyx/krypton/configuration/Option.java
@@ -2,6 +2,7 @@ package com.archyx.krypton.configuration;
 
 public enum Option {
 
+    API_MODE("api_mode", OptionType.BOOLEAN),
     CAPTCHA_EVERY_JOIN("captcha.every_join", OptionType.BOOLEAN),
     ENABLE_FAIL_KICK("captcha.enable_fail_kick", OptionType.BOOLEAN),
     FAIL_KICK_MAX_ATTEMPTS("captcha.fail_kick_max_attempts", OptionType.INT),

--- a/src/main/java/com/archyx/krypton/data/DataLoader.java
+++ b/src/main/java/com/archyx/krypton/data/DataLoader.java
@@ -50,7 +50,7 @@ public class DataLoader {
             config.set("failed_players." + player.getId().toString(), player.getFailedAttempts());
         }
         for (CaptchaPlayer player : manager.getCaptchaPlayers().values()) {
-            config.set("failed_players." + player.getPlayer().getUniqueId().toString(), player.getTotalFailedAttempts());
+            config.set("failed_players." + player.getPlayer().getUniqueId(), player.getTotalFailedAttempts());
         }
         try {
             config.save(file);

--- a/src/main/java/com/archyx/krypton/events/PlayerCaptchaActivateEvent.java
+++ b/src/main/java/com/archyx/krypton/events/PlayerCaptchaActivateEvent.java
@@ -1,0 +1,48 @@
+package com.archyx.krypton.events;
+
+import com.archyx.krypton.captcha.CaptchaActivateReason;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerCaptchaActivateEvent extends Event implements Cancellable {
+
+    public PlayerCaptchaActivateEvent(
+        final Player player,
+        final CaptchaActivateReason activateReason
+    ) {
+        this.player = player;
+        this.activateReason = activateReason;
+    }
+
+    final Player player;
+    final CaptchaActivateReason activateReason;
+
+    public Player getPlayer() { return player; }
+    public CaptchaActivateReason getActivateReason() { return activateReason; }
+
+    private boolean isCancelled;
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean isCancelled) {
+        this.isCancelled = isCancelled;
+    }
+
+    private static final HandlerList handlerList = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlerList;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+}

--- a/src/main/java/com/archyx/krypton/events/PlayerCaptchaFailEvent.java
+++ b/src/main/java/com/archyx/krypton/events/PlayerCaptchaFailEvent.java
@@ -1,0 +1,29 @@
+package com.archyx.krypton.events;
+
+import com.archyx.krypton.captcha.CaptchaPlayer;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerCaptchaFailEvent extends Event {
+
+    public PlayerCaptchaFailEvent(
+        final CaptchaPlayer captchaPlayer
+    ) {
+        this.captchaPlayer = captchaPlayer;
+    }
+    final CaptchaPlayer captchaPlayer;
+
+    public CaptchaPlayer getCaptchaPlayer() { return captchaPlayer; }
+
+    private static final HandlerList handlerList = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlerList;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+}

--- a/src/main/java/com/archyx/krypton/events/PlayerCaptchaSolveEvent.java
+++ b/src/main/java/com/archyx/krypton/events/PlayerCaptchaSolveEvent.java
@@ -1,0 +1,29 @@
+package com.archyx.krypton.events;
+
+import com.archyx.krypton.captcha.CaptchaPlayer;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerCaptchaSolveEvent extends Event {
+
+    public PlayerCaptchaSolveEvent(
+        final CaptchaPlayer captchaPlayer
+    ) {
+        this.captchaPlayer = captchaPlayer;
+    }
+    final CaptchaPlayer captchaPlayer;
+
+    public CaptchaPlayer getCaptchaPlayer() { return captchaPlayer; }
+
+    private static final HandlerList handlerList = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlerList;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+}

--- a/src/main/java/com/archyx/krypton/events/PlayerQuitDuringCaptchaEvent.java
+++ b/src/main/java/com/archyx/krypton/events/PlayerQuitDuringCaptchaEvent.java
@@ -1,0 +1,29 @@
+package com.archyx.krypton.events;
+
+import com.archyx.krypton.captcha.CaptchaPlayer;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerQuitDuringCaptchaEvent extends Event {
+
+    public PlayerQuitDuringCaptchaEvent(
+        final CaptchaPlayer captchaPlayer
+    ) {
+        this.captchaPlayer = captchaPlayer;
+    }
+    final CaptchaPlayer captchaPlayer;
+
+    public CaptchaPlayer getCaptchaPlayer() { return captchaPlayer; }
+
+    private static final HandlerList handlerList = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlerList;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+}

--- a/src/main/java/com/archyx/krypton/listeners/CaptchaActivator.java
+++ b/src/main/java/com/archyx/krypton/listeners/CaptchaActivator.java
@@ -1,6 +1,7 @@
 package com.archyx.krypton.listeners;
 
 import com.archyx.krypton.Krypton;
+import com.archyx.krypton.captcha.CaptchaActivateReason;
 import com.archyx.krypton.captcha.CaptchaManager;
 import com.archyx.krypton.captcha.CaptchaMenu;
 import com.archyx.krypton.captcha.CaptchaPlayer;
@@ -8,7 +9,10 @@ import com.archyx.krypton.captcha.OfflineCaptchaPlayer;
 import com.archyx.krypton.configuration.CaptchaMode;
 import com.archyx.krypton.configuration.Option;
 import com.archyx.krypton.configuration.OptionL;
+import com.archyx.krypton.events.PlayerCaptchaActivateEvent;
+import com.archyx.krypton.events.PlayerQuitDuringCaptchaEvent;
 import com.archyx.krypton.messages.MessageKey;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -31,45 +35,55 @@ public class CaptchaActivator implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
+
         if (!manager.isEnabled()) return; // Check if enabled
+
         if (manager.isOfflineCaptchaPlayer(player.getUniqueId())) {
-            activate(player, manager.getOfflineCaptchaPlayers().get(player.getUniqueId()).getFailedAttempts());
+            activate(
+                player,
+                manager.getOfflineCaptchaPlayers().get(player.getUniqueId()).getFailedAttempts(),
+                CaptchaActivateReason.FROM_PREVIOUS_SESSION
+            );
+
             manager.removeOfflineCaptchaPlayer(player.getUniqueId());
+            return;
         }
-        else if (!player.hasPlayedBefore()) {
-            activate(player, 0);
-            if (OptionL.getMode() == CaptchaMode.MAP) {
-                if (OptionL.getBoolean(Option.MAP_FORCE_PITCH_ENABLED)) {
-                    new BukkitRunnable() {
-                        @Override
-                        public void run() {
-                            Location location = player.getLocation();
-                            location.setPitch((float) OptionL.getDouble(Option.MAP_FORCE_PITCH_PITCH));
-                            player.teleport(location);
-                        }
-                    }.runTaskLater(plugin, 5L);
-                }
-            }
-        }
-        else if (OptionL.getBoolean(Option.CAPTCHA_EVERY_JOIN)) {
-            activate(player, 0);
+
+        if (OptionL.getBoolean(Option.API_MODE)) return; // Skip if API mode
+
+        if (!player.hasPlayedBefore() || OptionL.getBoolean(Option.CAPTCHA_EVERY_JOIN)) {
+            activate(player, 0, CaptchaActivateReason.FROM_JOIN);
         }
     }
 
-    public void activate(Player player, int failedAttempts) {
-        if (!manager.isCaptchaPlayer(player)) {
-            if (OptionL.getMode() == CaptchaMode.MAP) {
+    public void activate(Player player, int failedAttempts, final CaptchaActivateReason activateReason) {
+        if(manager.isCaptchaPlayer(player)) return;
+
+        /* Call the event */
+        final PlayerCaptchaActivateEvent activateEvent = new PlayerCaptchaActivateEvent(
+            player,
+            activateReason
+        );
+        Bukkit.getPluginManager().callEvent(activateEvent);
+        if(activateEvent.isCancelled()) return;
+
+        switch(OptionL.getMode()) {
+            case MAP:
                 activateMapCaptcha(player, failedAttempts);
-            }
-            else if (OptionL.getMode() == CaptchaMode.MENU) {
+                break;
+            case MENU:
                 activateMenuCaptcha(player, failedAttempts);
-            }
+                break;
+            default:
+                throw new IllegalStateException("Unexpected state: " + OptionL.getMode());
         }
     }
 
     private void activateMenuCaptcha(Player player, int failedAttempts) {
        CaptchaPlayer captchaPlayer = new CaptchaPlayer(player, CaptchaMode.MENU, failedAttempts);
+
        manager.addCaptchaPlayer(captchaPlayer);
+
        new BukkitRunnable() {
            @Override
            public void run() {
@@ -80,17 +94,20 @@ public class CaptchaActivator implements Listener {
 
     private void activateMapCaptcha(Player player, int failedAttempts) {
         CaptchaPlayer captchaPlayer = new CaptchaPlayer(player, CaptchaMode.MAP, failedAttempts);
+
         player.getInventory().setHeldItemSlot(0);
         captchaPlayer.setSlotItem(player.getInventory().getItem(0));
         String code = manager.getGenerator().generateCode();
         captchaPlayer.setMapCode(code);
         player.getInventory().setItem(0, manager.getGenerator().generateMap(player, code));
+
         //Force pitch if enabled
         if (OptionL.getBoolean(Option.MAP_FORCE_PITCH_ENABLED)) {
             Location location = player.getLocation();
             location.setPitch((float) OptionL.getDouble(Option.MAP_FORCE_PITCH_PITCH));
             player.teleport(location);
         }
+
         //Allow move if enabled
         if (OptionL.getBoolean(Option.MAP_ALLOW_MOVE_ENABLED)) {
             captchaPlayer.setAllowMove(true);
@@ -100,40 +117,42 @@ public class CaptchaActivator implements Listener {
                     captchaPlayer.setAllowMove(false);
                 }
             }.runTaskLater(plugin, Math.abs(OptionL.getInt(Option.MAP_ALLOW_MOVE_DURATION_TICKS)));
-        }
-        else {
+        } else {
             captchaPlayer.setAllowMove(false);
         }
         player.sendMessage(plugin.getMessage(MessageKey.MAP_INFO));
-        scheduleTask(player);
-        manager.addCaptchaPlayer(captchaPlayer);
-    }
 
-    private void scheduleTask(Player player) {
         new BukkitRunnable() {
             @Override
             public void run() {
                 if (manager.isCaptchaPlayer(player)) {
                     player.sendMessage(plugin.getMessage(MessageKey.MAP_INFO));
-                }
-                else {
+                } else {
                     cancel();
                 }
             }
         }.runTaskTimer(plugin, 100L, 100L);
+
+        manager.addCaptchaPlayer(captchaPlayer);
     }
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
         Player player = event.getPlayer();
         CaptchaPlayer captchaPlayer = manager.getCaptchaPlayer(player);
-        if (captchaPlayer != null) {
-            if (captchaPlayer.getMode() == CaptchaMode.MAP) {
-                player.getInventory().setItem(0, captchaPlayer.getSlotItem());
-            }
-            manager.removeCaptchaPlayer(player);
-            manager.addOfflineCaptchaPlayer(new OfflineCaptchaPlayer(player.getUniqueId(), captchaPlayer.getTotalFailedAttempts()));
+        if (captchaPlayer == null) return;
+
+        if (captchaPlayer.getMode() == CaptchaMode.MAP) {
+            player.getInventory().setItem(0, captchaPlayer.getSlotItem());
         }
+
+        manager.removeCaptchaPlayer(player);
+        manager.addOfflineCaptchaPlayer(new OfflineCaptchaPlayer(
+            player.getUniqueId(),
+            captchaPlayer.getTotalFailedAttempts()
+        ));
+
+        Bukkit.getPluginManager().callEvent(new PlayerQuitDuringCaptchaEvent(captchaPlayer));
     }
 
 }

--- a/src/main/java/com/archyx/krypton/listeners/CaptchaListener.java
+++ b/src/main/java/com/archyx/krypton/listeners/CaptchaListener.java
@@ -6,7 +6,10 @@ import com.archyx.krypton.Krypton;
 import com.archyx.krypton.configuration.CaptchaMode;
 import com.archyx.krypton.configuration.Option;
 import com.archyx.krypton.configuration.OptionL;
+import com.archyx.krypton.events.PlayerCaptchaFailEvent;
+import com.archyx.krypton.events.PlayerCaptchaSolveEvent;
 import com.archyx.krypton.messages.MessageKey;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -33,11 +36,16 @@ public class CaptchaListener implements Listener {
             event.setCancelled(true);
             if (captchaPlayer.getMode() == CaptchaMode.MAP) {
                 if (ChatColor.stripColor(event.getMessage()).equals(captchaPlayer.getMapCode())) {
+                    Bukkit.getPluginManager().callEvent(new PlayerCaptchaSolveEvent(captchaPlayer));
+
                     player.sendMessage(plugin.getMessage(MessageKey.COMPLETE));
                     player.getInventory().setItem(0, captchaPlayer.getSlotItem());
                     manager.removeCaptchaPlayer(player);
                 } else {
+                    Bukkit.getPluginManager().callEvent(new PlayerCaptchaFailEvent(captchaPlayer));
+
                     player.sendMessage(plugin.getMessage(MessageKey.MAP_INCORRECT));
+
                     if (OptionL.getBoolean(Option.ENABLE_FAIL_KICK)) {
                         captchaPlayer.incrementFailedAttempts();
                         if (captchaPlayer.getFailedAttempts() >= OptionL.getInt(Option.FAIL_KICK_MAX_ATTEMPTS)) {

--- a/src/main/java/com/archyx/krypton/listeners/PacketListener.java
+++ b/src/main/java/com/archyx/krypton/listeners/PacketListener.java
@@ -6,6 +6,8 @@ import com.archyx.krypton.Krypton;
 import com.archyx.krypton.configuration.CaptchaMode;
 import com.archyx.krypton.configuration.Option;
 import com.archyx.krypton.configuration.OptionL;
+import com.archyx.krypton.events.PlayerCaptchaFailEvent;
+import com.archyx.krypton.events.PlayerCaptchaSolveEvent;
 import com.archyx.krypton.messages.MessageKey;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
@@ -14,6 +16,7 @@ import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -45,12 +48,16 @@ public class PacketListener {
                     event.setCancelled(true);
                     if (captchaPlayer.getMode() == CaptchaMode.MAP) {
                         if (ChatColor.stripColor(message).equals(captchaPlayer.getMapCode())) {
+                            Bukkit.getPluginManager().callEvent(new PlayerCaptchaSolveEvent(captchaPlayer));
+
                             player.sendMessage(krypton.getMessage(MessageKey.COMPLETE));
                             player.getInventory().setItem(0, captchaPlayer.getSlotItem());
                             manager.removeCaptchaPlayer(player);
-                        }
-                        else {
+                        } else {
+                            Bukkit.getPluginManager().callEvent(new PlayerCaptchaFailEvent(captchaPlayer));
+
                             player.sendMessage(krypton.getMessage(MessageKey.MAP_INCORRECT));
+
                             if (OptionL.getBoolean(Option.ENABLE_FAIL_KICK)) {
                                 captchaPlayer.incrementFailedAttempts();
                                 if (captchaPlayer.getFailedAttempts() >= OptionL.getInt(Option.FAIL_KICK_MAX_ATTEMPTS)) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,4 @@
 # Krypton Configuration
-# Version 1.0.0
 # Plugin by Archyx
 
 captcha:
@@ -22,3 +21,5 @@ captcha:
       pitch: 80.0
   menu:
     reopen_delay: 40
+
+api_mode: false

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,5 +1,5 @@
 map:
-  info: '&cEnter the code on the map in chat to be verified'
+  info: '&cEnter the code on the map in chat to be verified.'
   incorrect: '&eCaptcha incorrect, try again!'
 menu:
   title: Click the item to be verified
@@ -10,13 +10,13 @@ complete: '&aCaptcha completed!'
 commands:
   reload: '&aConfig reloaded!'
   unlock:
-    sender: '&6{player} has been unlocked from the captcha!'
+    sender: '&6{player} &ahas been unlocked from the captcha!'
     target: '&bYou have been unlocked from the captcha!'
     not_found: '&6{player} &cis not in a captcha!'
   enable:
-    enabled: '&aCaptcha has been enabled'
+    enabled: '&aCaptcha has been enabled.'
     already_enabled: '&eCaptcha is already enabled!'
   disable:
-    disabled: '&cCaptcha has been disabled'
+    disabled: '&cCaptcha has been disabled.'
     already_disabled: '&eCaptcha is already disabled!'
 file_version: 2


### PR DESCRIPTION
Hi,

I've made the following changes:

* Adds the `api_mode` setting (boolean) to `config.yml`: makes Krypton API-only (no on-join captcha activation except for checking offline captcha players). 
* Adds 4 events.
* The CaptchaActivator is now accessible from the main class so that other plugins can activate a Captcha for a player.
* Added the `CaptchaActivateReason`, this is useful to check why a player has had a Captcha activated.
* Minor improvements to the messages file - some messages were missing a color code or full stop.
* Removes the `Version` comment from `config.yml`. I found this was unnecessary and it was missed last update.
* Minor code improvements.
* Updated bStats to `v3.0.0`.
* Changed version to `v1.1.0-SNAPSHOT`.

Feel free to edit this branch, merge, close, whatever you like. I'm using these changes myself, so that I can make my plugin manually activate the Captcha instead of having Krypton do that on-join. :smiley: